### PR TITLE
Read directly from safari history

### DIFF
--- a/safari_to_sqlite/__main__.py
+++ b/safari_to_sqlite/__main__.py
@@ -2,12 +2,10 @@
 
 import logging
 import time
-from collections import Counter
-from functools import reduce
+from collections.abc import Iterable
 from pathlib import Path
 from socket import gethostname
 from sys import argv, stderr
-from typing import Iterable
 
 from loguru import logger
 
@@ -45,7 +43,7 @@ def auth(auth_path: str) -> None:
 def save(
     db_path: str,
     auth_json: str,
-) -> None:
+) -> Datastore:
     """Save Safari tabs to SQLite database."""
     host = gethostname()
     first_seen = int(time.time())
@@ -56,9 +54,10 @@ def save(
 
     db = _insert_tabs(db_path, auth_json, tabs)
     request_missing_bodies(db, auth_json)
+    return db
 
 
-def _insert_tabs(db_path: str, auth_json: str, tabs: Iterable[TabRow]):
+def _insert_tabs(db_path: str, auth_json: str, tabs: Iterable[TabRow]) -> Datastore:
     tabs = [tab for tab in tabs if filter_blacklist(tab.url)]
     logger.info(f"Found {len(tabs)} tabs")
     db = Datastore(db_path, **get_auth_creds_from_json(auth_json))
@@ -81,7 +80,7 @@ def _configure_logging() -> None:
     remote_client_logger.setLevel(logging.WARNING)
 
 
-def request_missing_bodies(db_path: str | Datastore, auth_json: str) -> None:
+def request_missing_bodies(db_path: str | Datastore, auth_json: str) -> Datastore:
     """Request body when missing and save extracted contents."""
     db: Datastore = (
         db_path
@@ -98,10 +97,12 @@ def request_missing_bodies(db_path: str | Datastore, auth_json: str) -> None:
         except FailedDownloadError as e:
             logger.error(f"Failed to download ({e.code}): {url}")
             db.update_body(url, e.code)
+    return db
 
 
-def save_history(db_path: str, auth_json: str) -> None:
-    _insert_tabs(db_path, auth_json, read_history())
+def save_history(db_path: str, auth_json: str) -> Datastore:
+    """Save complete Safari history to SQLite database."""
+    return _insert_tabs(db_path, auth_json, read_history())
 
 
 def main() -> None:
@@ -110,22 +111,25 @@ def main() -> None:
     db_default = str(Path.home() / "Documents/tabs.db")
     auth_default = "auth.json"
     if len(argv) == 1 or argv[1].endswith(".db"):
-        db = argv[1] if len(argv) > 1 else db_default
+        db_path = argv[1] if len(argv) > 1 else db_default
         auth_path = argv[2] if len(argv) > 2 else auth_default  # noqa: PLR2004
-        save(db, auth_path)
+        db = save(db_path, auth_path)
     elif argv[1] == "auth":
+        db = None
         auth_path = argv[1] if len(argv) > 1 else auth_default
         auth(auth_path)
     elif argv[1] == "download":
-        db = argv[2] if len(argv) > 2 else db_default  # noqa: PLR2004
+        db_path = argv[2] if len(argv) > 2 else db_default  # noqa: PLR2004
         auth_path = argv[3] if len(argv) > 3 else auth_default  # noqa: PLR2004
-        request_missing_bodies(db, auth_path)
+        db = request_missing_bodies(db_path, auth_path)
     elif argv[1] == "history":
-        db = argv[2] if len(argv) > 2 else db_default  # noqa: PLR2004
+        db_path = argv[2] if len(argv) > 2 else db_default  # noqa: PLR2004
         auth_path = argv[3] if len(argv) > 3 else auth_default  # noqa: PLR2004
-        save_history(db, auth_path)
+        db = save_history(db_path, auth_path)
     else:
-        pass
+        return
+    if db:
+        db.close()
 
 
 if __name__ == "__main__":

--- a/safari_to_sqlite/constants.py
+++ b/safari_to_sqlite/constants.py
@@ -16,7 +16,7 @@ TURSO_URL = "turso_url"
 TURSO_AUTH_TOKEN = "turso_auth_token"  # noqa: S105
 
 
-class ScrapeStatus(Enum):
+class ScrapeStatus(int, Enum):
     """Enum for scrape status."""
 
     NotScraped = -1
@@ -24,10 +24,11 @@ class ScrapeStatus(Enum):
     UnicodeFailed = -3
 
 
-class Browser(Enum):
+class Browser(str, Enum):
     """Enum for browser."""
 
     Safari = "safari"
+    iCloud = "icloud"
     Chrome = "chrome"
 
 

--- a/safari_to_sqlite/constants.py
+++ b/safari_to_sqlite/constants.py
@@ -28,7 +28,7 @@ class Browser(str, Enum):
     """Enum for browser."""
 
     Safari = "safari"
-    iCloud = "icloud"
+    Icloud = "icloud"
     Chrome = "chrome"
 
 

--- a/safari_to_sqlite/datastore.py
+++ b/safari_to_sqlite/datastore.py
@@ -124,3 +124,11 @@ class Datastore:
             )
         self.con.execute(stmt, (body, url))
         self.con.commit()
+
+    def close(self) -> None:
+        """Close the connection."""
+        try:
+            self.con.sync()
+            self.con.close()
+        except (AttributeError, ValueError):
+            pass

--- a/safari_to_sqlite/download.py
+++ b/safari_to_sqlite/download.py
@@ -6,7 +6,7 @@ from safari_to_sqlite.errors import FailedDownloadError
 
 
 def _download(url: str) -> str:
-    response: Response = get(url, max_redirects=5)
+    response: Response = get(url, max_redirects=2)
     if not response.ok:
         raise FailedDownloadError(response.status_code)
     try:

--- a/safari_to_sqlite/history.py
+++ b/safari_to_sqlite/history.py
@@ -7,8 +7,8 @@ from safari_to_sqlite.datastore import TabRow
 
 
 def read_history() -> Iterable[TabRow]:
+    """Read Safari history from local SQLite database."""
     db_path = Path.home() / "Library/Safari/History.db"
-    print(db_path)
     con = sqlite3.connect(db_path)
     query = (
         "SELECT history_items.url, title, visit_time, history_visits.origin "
@@ -26,7 +26,7 @@ def read_history() -> Iterable[TabRow]:
             host="",
             first_seen=int(row[2]),
             scrape_status=-1,
-            browser=Browser.Safari.value if row[3] == 1 else Browser.iCloud.value,
+            browser=Browser.Safari.value if row[3] == 1 else Browser.Icloud.value,
         )
     cur.close()
     con.close()

--- a/safari_to_sqlite/history.py
+++ b/safari_to_sqlite/history.py
@@ -1,0 +1,32 @@
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+
+from safari_to_sqlite.constants import Browser
+from safari_to_sqlite.datastore import TabRow
+
+
+def read_history() -> Iterable[TabRow]:
+    db_path = Path.home() / "Library/Safari/History.db"
+    print(db_path)
+    con = sqlite3.connect(db_path)
+    query = (
+        "SELECT history_items.url, title, visit_time, history_visits.origin "
+        "FROM history_visits LEFT JOIN history_items "
+        "ON history_visits.history_item=history_items.id;"
+    )
+    cur = con.cursor()
+    for row in cur.execute(query):
+        yield TabRow(
+            url=row[0],
+            title=row[1] or "",
+            body="",
+            window_id=-1,
+            tab_index=-1,
+            host="",
+            first_seen=int(row[2]),
+            scrape_status=-1,
+            browser=Browser.Safari.value if row[3] == 1 else Browser.iCloud.value,
+        )
+    cur.close()
+    con.close()

--- a/safari_to_sqlite/safari.py
+++ b/safari_to_sqlite/safari.py
@@ -13,17 +13,15 @@ def _get_safari_tabs_raw() -> list[str]:
     return result.stderr.decode().strip().splitlines()
 
 
-def get_safari_tabs(host: str, first_seen: int) -> tuple[list[TabRow], list[str]]:
+def get_safari_tabs(host: str, first_seen: int) -> list[TabRow]:
     """Return all tabs."""
     output_iter = iter(_get_safari_tabs_raw())
     tabs = []
     output_available = True
-    urls = []
 
     while output_available:
         try:
             url = next(output_iter)
-            urls.append(url)
             title = next(output_iter)
             window_id = int(next(output_iter))
             tab_index = int(next(output_iter))
@@ -47,4 +45,4 @@ def get_safari_tabs(host: str, first_seen: int) -> tuple[list[TabRow], list[str]
         except StopIteration:
             output_available = False
 
-    return tabs, urls
+    return tabs


### PR DESCRIPTION
TODO: parallelize body extraction, sync plugins

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the ability to read Safari history directly and save it to the database. It also includes refactoring of the `get_safari_tabs` function and updates to the `ScrapeStatus` and `Browser` enums for improved type safety.

- **New Features**:
    - Added functionality to read Safari history directly and save it to the database.
- **Enhancements**:
    - Refactored the `get_safari_tabs` function to simplify its return type.
    - Updated `ScrapeStatus` and `Browser` enums to include new types and improve type safety.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to save Safari browsing history to a database.
  - Introduced support for iCloud in the browser enumeration.

- **Improvements**
  - Default database path now uses the user's Documents directory for better accessibility.
  - Enhanced tab filtering and insertion logic for improved data handling.

- **Bug Fixes**
  - Limited redirects to a maximum of 2 when downloading, improving request stability.
  - Added error handling when closing database connections to prevent crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->